### PR TITLE
Fix using @babe/core code without lodash

### DIFF
--- a/babel-watch.js
+++ b/babel-watch.js
@@ -11,6 +11,7 @@ const util = require('util');
 const fork = require('child_process').fork;
 const execSync = require('child_process').execSync;
 const commander = require('commander');
+const _ = require("lodash");
 
 const RESTART_COMMAND = 'rs';
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "@babel/core": "^7.0.0-beta.44",
     "chokidar": "^1.4.3",
     "commander": "^2.9.0",
-    "source-map-support": "^0.4.0"
+    "source-map-support": "^0.4.0",
+    "lodash": "^4.17.11",
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0"


### PR DESCRIPTION
Part of code from `@babel/core` was require `lodash`, but `lodash` not imported